### PR TITLE
Fix unhandled fz exception.

### DIFF
--- a/MuPDFlib/MuPDFClass.cpp
+++ b/MuPDFlib/MuPDFClass.cpp
@@ -38,7 +38,7 @@ int MuPDFClass::LoadPdf(char* filename, char* password)
 	}
 	fz_catch(_ctx)
 	{
-		fz_throw(_ctx, FZ_ERROR_GENERIC, "cannot open document: %s", filename);
+		return -1;
 	}
 	return -1;
 }
@@ -57,7 +57,7 @@ int MuPDFClass::LoadPdfFromStream(unsigned char* buffer, int bufferSize, char* p
 	}
 	fz_catch(_ctx)
 	{
-		fz_throw(_ctx, FZ_ERROR_GENERIC, "cannot open stream!");
+		return -1;
 	}
 	return -1;
 }


### PR DESCRIPTION
Return -1 for page count instead of throwing an exception which will not be caught. The -1 will be interpreted higher in the call stack as "unable to open PDF."